### PR TITLE
Add more fallback translator options

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ Options:
     The translated lines per user and assistant message pairs are sliced as defined by `--history-prompt-length` (by default `--history-prompt-length 10`), it is recommended to set this to the largest batch size (by default `--batch-sizes "[10,100]"`): `--history-prompt-length 100`.  
     
     Enabling this may risk running into the model's context window limit, typically `128K`, but should be sufficient for most cases.
+  - `--experimental-fallback-model <value>`  
+    Model to be used for refusal fallback
+  - `--experimental-unstructured-fallback`  
+    Enable unstructured mode fallback when using structured mode with fallback model
   - `--log-level <level>`  
     Log level (default: `debug`, choices: `trace`, `debug`, `info`, `warn`, `error`, `silent`)
   - `--silent`  

--- a/cli/translator.mjs
+++ b/cli/translator.mjs
@@ -56,6 +56,7 @@ export function createInstance(args)
         .option("--experimental-max_token <value>", "", parseInt, 0)
         .option("--experimental-input-multiplier <value>", "", parseInt, 0)
         .option("--experimental-fallback-model <value>", "Model to be used for refusal fallback")
+        .option("--experimental-unstructured-fallback", "Enable unstructured mode fallback when using structured mode with fallback model")
         .addOption(new Option("--experimental-structured-mode [mode]", "Enable structured response formats as outlined by https://openai.com/index/introducing-structured-outputs-in-the-api/").choices(["array", "object"]))
         .option("--experimental-use-full-context", "Use the full history, chunked by historyPromptLength, to work better with prompt caching.")
 
@@ -70,10 +71,10 @@ export function createInstance(args)
         // .option("--n <n>", "Number of chat completion choices to generate for each input message", parseInt)
         // .option("--stop <stop>", "Up to 4 sequences where the API will stop generating further tokens")
         // .option("--max-tokens <max_tokens>", "The maximum number of tokens to generate in the chat completion", parseInt)
-        .option("--top_p <top_p>", "Nucleus sampling parameter, top_p probability mass https://platform.openai.com/docs/api-reference/chat/create#chat/create-top_p", parseFloat)
-        .option("--presence_penalty <presence_penalty>", "Penalty for new tokens based on their presence in the text so far https://platform.openai.com/docs/api-reference/chat/create#chat/create-presence_penalty", parseFloat)
-        .option("--frequency_penalty <frequency_penalty>", "Penalty for new tokens based on their frequency in the text so far https://platform.openai.com/docs/api-reference/chat/create#chat/create-frequency_penalty", parseFloat)
-        .option("--logit_bias <logit_bias>", "Modify the likelihood of specified tokens appearing in the completion https://platform.openai.com/docs/api-reference/chat/create#chat/create-logit_bias", JSON.parse)
+        .option("--top_p <top_p>", "Nucleus sampling parameter, top_p probability mass https://platform.openai.com/docs/api-reference/chat/create#chat-create-top_p", parseFloat)
+        .option("--presence_penalty <presence_penalty>", "Penalty for new tokens based on their presence in the text so far https://platform.openai.com/docs/api-reference/chat/create#chat-create-presence_penalty", parseFloat)
+        .option("--frequency_penalty <frequency_penalty>", "Penalty for new tokens based on their frequency in the text so far https://platform.openai.com/docs/api-reference/chat/create#chat-create-frequency_penalty", parseFloat)
+        .option("--logit_bias <logit_bias>", "Modify the likelihood of specified tokens appearing in the completion https://platform.openai.com/docs/api-reference/chat/create#chat-create-logit_bias", JSON.parse)
         // .option("--user <user>", "A unique identifier representing your end-user")
         .addOption(new Option("--log-level <level>", "Log level").choices(["trace", "debug", "info", "warn", "error", "silent"]))
         .option("--silent", "Same as --log-level silent")
@@ -110,6 +111,7 @@ export function createInstance(args)
         ...(opts.experimentalInputMultiplier && { inputMultiplier: opts.experimentalInputMultiplier }),
         ...(opts.experimentalFallbackModel && { fallbackModel: opts.experimentalFallbackModel }),
         ...(opts.experimentalUseFullContext && { useFullContext: opts.experimentalUseFullContext }),
+        ...(opts.experimentalUnstructuredFallback && { unstructuredFallback: opts.experimentalUnstructuredFallback }),
         ...(opts.logLevel && { logLevel: opts.logLevel })
     };
 


### PR DESCRIPTION
Fixes #42

Implement a fallback translation engine for flagged or failed translations.

* **src/translator.mjs**
  - Add logic to handle fallback translation for flagged translations in the `translateLines` method.
  - Add logic to handle fallback translation for failed translations in the `translatePrompt` method.
  - Update the `yieldOutput` method to include fallback translation results.

* **cli/translator.mjs**
  - Add CLI flags for fallback model.
  - Add CLI option for unstructured mode fallback when using structured mode with fallback model.

* **README.md**
  - Update documentation to include details about the fallback translation engine.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Cerlancism/chatgpt-subtitle-translator/issues/42?shareId=94c82663-c5d3-4e6d-b001-40185e5eca1d).