### PR TITLE
feat: llm summary repetition guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ Options:
     However, mismatched output line quantities or exceeding the token limit will cause token wastage, requiring resubmission of the batch with a smaller batch size.
 
     When omitted, batch size is determined automatically per batch based on the `--context` token budget. On failure, the size is reduced and retried down to a minimum, then resets on the next successful batch.
-  - `--initial-prompts <prompts>`  
+  - `-g, --guard-repetition <threshold>`
+    Minimum number of pattern repeats before aborting a streaming response (default: `10`). When the model falls into a repetition loop during streaming, the response is aborted and retried with a smaller batch. Set to `0` to disable repetition detection.
+  - `--initial-prompts <prompts>`
     Initial prompts for the translation in JSON (default: `"[]"`) 
   - `--use-moderator`
     Use the OpenAI Moderation tool

--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ cli/translator.mjs agent --help
 Agent mode runs multiple passes before translating:
 
 **Overview** - Samples the file to produce a content overview (file identity, duration, genre/tone, character names) and detects the source language.  
-**Planning** - Scans the file in token-bounded windows. Each window produces a batch summary (characters, locations, events, tone) and determines a natural batch boundary. Summaries are consolidated and used to generate a refined translation instruction.  
-**Translation** - Translates using the enriched instruction and the agent-determined batch boundaries. After the first batch, a sample of the output is checked to confirm the target language before proceeding.  
+**Planning** - Scans the file in token-bounded windows. Each window produces a batch summary (characters, locations, events, tone). Summaries are consolidated and used to generate a refined translation instruction.  
+**Translation** - Translates using the enriched instruction. After the first batch, a sample of the output is checked to confirm the target language before proceeding.  
 
 Structured mode defaults to `array`; pass `--structured timestamp` to use timestamp mode instead.  
 
@@ -154,7 +154,7 @@ cli/translator.mjs agent --input subtitles.srt --structured timestamp --from Jap
 ```
 
 - `--skip-refine`  
-  Skip the final instruction refinement step at the end of the planning pass and use the accumulated summaries directly.
+  Skip the final instruction refinement step at the end of the planning pass and use the original system instruction directly.
 - `--context-summary <summary>`  
   Provide a context summary directly, bypassing the planning pass entirely and proceeding straight to translation.
 

--- a/cli/translator.mjs
+++ b/cli/translator.mjs
@@ -92,6 +92,7 @@ async function createInstance(args) {
     addTranslatorOptions(program.command("agent")
         .description("Agentic multi-pass translation: planning pass observes content before translating"))
         .option("--skip-refine", "Skip final instruction refinement and use the base instruction directly")
+        .option("--no-fitting", "Skip LLM-based token-range fitting for planning summaries and consolidation")
         .option("--context-summary <summary>", "Provide a context summary directly, skipping the batch summary scanning pass")
         .action(async (_, agentCmd) => {
             const opts = agentCmd.optsWithGlobals()
@@ -142,6 +143,7 @@ function buildOptions(opts) {
         ...(opts.logLevel && { logLevel: opts.logLevel }),
         ...(opts.input && { inputFile: opts.input }),
         ...(opts.skipRefine && { skipRefineInstruction: true }),
+        ...(opts.fitting === false && { skipFitting: true }),
         ...(opts.contextSummary && { agentContextSummary: opts.contextSummary })
     }
 

--- a/cli/translator.mjs
+++ b/cli/translator.mjs
@@ -68,6 +68,7 @@ function addTranslatorOptions(cmd) {
         .option("--no-prefix-number", "Don't prefix lines with numerical indices")
         .option("--no-line-matching", "Don't enforce one-to-one line quantity input output matching")
         .option("-b, --batch-sizes <sizes>", "Batch sizes for translation prompts in JSON Array. When omitted, batch size is determined automatically based on the context token budget", JSON.parse)
+        .option("-g, --guard-repetition <threshold>", "Minimum pattern repeats before aborting a streaming response. Set to 0 to disable", val => parseInt(val, 10), DefaultOptions.guardRepetition)
         .option("-t, --temperature <temperature>", "Sampling temperature to use, should set a low value such as 0 to be more deterministic", parseFloat, DefaultOptions.createChatCompletionRequest.temperature)
         .option("--no-stream", "Disable stream progress output to terminal (streaming is on by default)")
         .option("--top_p <top_p>", "Nucleus sampling parameter, top_p probability mass", parseFloat)
@@ -137,6 +138,7 @@ function buildOptions(opts) {
         ...(opts.experimentalMax_token && { max_token: opts.experimentalMax_token }),
         ...(opts.experimentalInputMultiplier && { inputMultiplier: opts.experimentalInputMultiplier }),
         ...(opts.context !== undefined && { useFullContext: opts.context }),
+        ...(opts.guardRepetition !== undefined && { guardRepetition: opts.guardRepetition }),
         ...(opts.logLevel && { logLevel: opts.logLevel }),
         ...(opts.input && { inputFile: opts.input }),
         ...(opts.skipRefine && { skipRefineInstruction: true }),

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 3.3.0 (2026-04-09)
+
+### New Features
+
+#### Stream Repetition Guard (`-g, --guard-repetition`)
+
+A new option that monitors streaming responses for looping output and aborts the request before it wastes too many tokens.
+
+- **`-g, --guard-repetition <threshold>`** - minimum number of times a pattern must repeat before the stream is aborted. Defaults to `10`. Set to `0` to disable.
+- On detection, the current batch is retried automatically.
+- Applied across all translation modes: plain, `array`, `object`, and `timestamp`.
+
+#### Agent Planning: LLM-Based Summary Fitting
+
+Planning pass summaries that fall outside the target token range are now re-fit using the `llm-summary` `summarise` function (two-phase draft → fit), replacing the previous direct model call for consolidation. This applies to both per-window batch summaries and accumulated consolidation steps.
+
+- **`--no-fitting`** — skip LLM-based fitting for both scan-window summaries and consolidation. Summaries are used as-is regardless of token range.
+
 ## 3.2.0 (2026-04-02)
 
 ### New Features
@@ -12,9 +30,9 @@ The agent mode has been expanded into a multi-pass pipeline:
 
 **Overview pass:** Samples the file to generate a content overview (file identity, duration, entry count, genre/tone, character names) and detects the source language.
 
-**Planning pass:** Scans the file in token-bounded windows derived from the context budget, rather than fixed max-batch-size chunks. Each window produces a batch summary and determines a natural batch boundary. Summaries are consolidated and used to generate a refined translation instruction. The final refinement step can be skipped with `--skip-refine`.
+**Planning pass:** Scans the file in token-bounded windows derived from the context budget, rather than fixed max-batch-size chunks. Each window produces a batch summary. Summaries are consolidated and used to generate a refined translation instruction. The final refinement step can be skipped with `--skip-refine`.
 
-**Translation pass:** Uses the enriched instruction and agent-determined batch boundaries. The delegate translation mode defaults to `array`; pass `-r timestamp` alongside the `agent` subcommand to use timestamp mode instead.
+**Translation pass:** Uses the enriched instruction. The delegate translation mode defaults to `array`; pass `-r timestamp` alongside the `agent` subcommand to use timestamp mode instead.
 
 ```bash
 # Default (array delegate)
@@ -44,9 +62,9 @@ When `--batch-sizes` is omitted, the batch size is now derived automatically fro
 
 A multi-pass agentic translation mode.
 
-**Planning pass:** Scans the full subtitle file in max-batch-size chunks. For each chunk the model produces a batch summary (character names, locations, events, tone, dialect) and decides a natural batch boundary. Summaries accumulate and are consolidated when they exceed the token budget. At the end of the scan, a refined system instruction is generated that filters the glossary and stylistic notes down to only what was observed in the file.
+**Planning pass:** Scans the full subtitle file in max-batch-size chunks. For each chunk the model produces a batch summary (character names, locations, events, tone, dialect). Summaries accumulate and are consolidated when they exceed the token budget. At the end of the scan, a refined system instruction is generated that filters the glossary and stylistic notes down to only what was observed in the file.
 
-**Translation pass:** Runs identically to `timestamp` mode using the enriched instruction and the agent-determined batch boundaries from the planning pass.
+**Translation pass:** Runs identically to `timestamp` mode using the enriched instruction.
 
 Best suited for content with recurring characters, specialized vocabulary, or stylistic consistency requirements. Costs additional API calls for the planning pass. Progress file resumption is not supported.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "commander": "^14.0.3",
         "dotenv": "^17.3.1",
         "gpt-tokenizer": "^3.4.0",
-        "llm-summary": "github:Cerlancism/llm-summary#3391cc3e51f00c81629d2d7a721ce50f7e537ed2",
+        "llm-summary": "github:Cerlancism/llm-summary#85ffd95f01a52a26750f7a69232cca31faa2abe0",
         "loglevel": "^1.9.2",
         "openai": "^6.22.0",
         "srt-parser-2": "^1.2.3",
@@ -85,7 +85,8 @@
     },
     "node_modules/llm-summary": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/Cerlancism/llm-summary.git#3391cc3e51f00c81629d2d7a721ce50f7e537ed2",
+      "resolved": "git+ssh://git@github.com/Cerlancism/llm-summary.git#85ffd95f01a52a26750f7a69232cca31faa2abe0",
+      "integrity": "sha512-m7ZIEZ7cHISbMxmPehOcbRnI4yOT3dhJnP9HIfWJ7F77uevn7f28eWIfPT0l3zozH3kH+jus6agWyHa7pup8rA==",
       "dependencies": {
         "dotenv": "^16.4.7",
         "gpt-tokenizer": "^3.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "commander": "14.0.3",
         "dotenv": "17.4.1",
         "gpt-tokenizer": "3.4.0",
-        "llm-summary": "github:Cerlancism/llm-summary#fe65dee4a8c70032a611bec6ca31906ae5abbcc2",
+        "llm-summary": "github:Cerlancism/llm-summary#b58ba2cb967aedfa33973c0bd16d0610f614a568",
         "loglevel": "1.9.2",
         "openai": "6.33.0",
         "srt-parser-2": "1.2.3",
@@ -85,8 +85,8 @@
     },
     "node_modules/llm-summary": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/Cerlancism/llm-summary.git#fe65dee4a8c70032a611bec6ca31906ae5abbcc2",
-      "integrity": "sha512-kzFJvee21siH+laa9i2ifxyFg57DFCr2hBES+Ua6/Jk0/1toifvfVAPab1SyKjX16i4T/QXC76+vlVmwbXeBzA==",
+      "resolved": "git+ssh://git@github.com/Cerlancism/llm-summary.git#b58ba2cb967aedfa33973c0bd16d0610f614a568",
+      "integrity": "sha512-4GY1LYfokEioBFI0O2pIcYhnGijD+OAzLYYOhPTiFWFNcZXZGSYv/axb2EisKxiqhCy6b9sCujVBF0p7G9Ve5w==",
       "dependencies": {
         "dotenv": "17.4.1",
         "gpt-tokenizer": "3.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,24 +9,24 @@
       "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
-        "@streamparser/json-node": "^0.0.22",
-        "@toon-format/toon": "^2.1.0",
-        "commander": "^14.0.3",
-        "dotenv": "^17.3.1",
-        "gpt-tokenizer": "^3.4.0",
-        "llm-summary": "github:Cerlancism/llm-summary#85ffd95f01a52a26750f7a69232cca31faa2abe0",
-        "loglevel": "^1.9.2",
-        "openai": "^6.22.0",
-        "srt-parser-2": "^1.2.3",
-        "undici": "^7.22.0",
-        "zod": "^4.3.6"
+        "@streamparser/json-node": "0.0.22",
+        "@toon-format/toon": "2.1.0",
+        "commander": "14.0.3",
+        "dotenv": "17.4.1",
+        "gpt-tokenizer": "3.4.0",
+        "llm-summary": "github:Cerlancism/llm-summary#fe65dee4a8c70032a611bec6ca31906ae5abbcc2",
+        "loglevel": "1.9.2",
+        "openai": "6.33.0",
+        "srt-parser-2": "1.2.3",
+        "undici": "8.0.2",
+        "zod": "4.3.6"
       },
       "bin": {
         "chatgpt-subtitle-translator": "cli/translator.mjs"
       },
       "devDependencies": {
         "@types/node": "^20",
-        "typescript": "^5.9.3"
+        "typescript": "5.9.3"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -68,9 +68,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
-      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
+      "integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
       "engines": {
         "node": ">=12"
       },
@@ -85,28 +85,16 @@
     },
     "node_modules/llm-summary": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/Cerlancism/llm-summary.git#85ffd95f01a52a26750f7a69232cca31faa2abe0",
-      "integrity": "sha512-m7ZIEZ7cHISbMxmPehOcbRnI4yOT3dhJnP9HIfWJ7F77uevn7f28eWIfPT0l3zozH3kH+jus6agWyHa7pup8rA==",
+      "resolved": "git+ssh://git@github.com/Cerlancism/llm-summary.git#fe65dee4a8c70032a611bec6ca31906ae5abbcc2",
+      "integrity": "sha512-kzFJvee21siH+laa9i2ifxyFg57DFCr2hBES+Ua6/Jk0/1toifvfVAPab1SyKjX16i4T/QXC76+vlVmwbXeBzA==",
       "dependencies": {
-        "dotenv": "^16.4.7",
-        "gpt-tokenizer": "^3.4.0",
-        "openai": "^6.32.0",
-        "zod": "^4.3.6"
+        "dotenv": "17.4.1",
+        "gpt-tokenizer": "3.4.0",
+        "openai": "6.33.0",
+        "zod": "4.3.6"
       },
       "bin": {
         "llm-summary": "dist/cli/index.js"
-      }
-    },
-    "node_modules/llm-summary/node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/loglevel": {
@@ -167,11 +155,11 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.0.2.tgz",
+      "integrity": "sha512-B9MeU5wuFhkFAuNeA19K2GDFcQXZxq33fL0nRy2Aq30wdufZbyyvxW3/ChaeipXVfy/wUweZyzovQGk39+9k2w==",
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "commander": "^14.0.3",
         "dotenv": "^17.3.1",
         "gpt-tokenizer": "^3.4.0",
+        "llm-summary": "github:Cerlancism/llm-summary#3391cc3e51f00c81629d2d7a721ce50f7e537ed2",
         "loglevel": "^1.9.2",
         "openai": "^6.22.0",
         "srt-parser-2": "^1.2.3",
@@ -82,6 +83,31 @@
       "resolved": "https://registry.npmjs.org/gpt-tokenizer/-/gpt-tokenizer-3.4.0.tgz",
       "integrity": "sha512-wxFLnhIXTDjYebd9A9pGl3e31ZpSypbpIJSOswbgop5jLte/AsZVDvjlbEuVFlsqZixVKqbcoNmRlFDf6pz/UQ=="
     },
+    "node_modules/llm-summary": {
+      "version": "1.0.0",
+      "resolved": "git+ssh://git@github.com/Cerlancism/llm-summary.git#3391cc3e51f00c81629d2d7a721ce50f7e537ed2",
+      "dependencies": {
+        "dotenv": "^16.4.7",
+        "gpt-tokenizer": "^3.4.0",
+        "openai": "^6.32.0",
+        "zod": "^4.3.6"
+      },
+      "bin": {
+        "llm-summary": "dist/cli/index.js"
+      }
+    },
+    "node_modules/llm-summary/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/loglevel": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
@@ -95,9 +121,10 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.22.0.tgz",
-      "integrity": "sha512-7Yvy17F33Bi9RutWbsaYt5hJEEJ/krRPOrwan+f9aCPuMat1WVsb2VNSII5W1EksKT6fF69TG/xj4XzodK3JZw==",
+      "version": "6.33.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.33.0.tgz",
+      "integrity": "sha512-xAYN1W3YsDXJWA5F277135YfkEk6H7D3D6vWwRhJ3OEkzRgcyK8z/P5P9Gyi/wB4N8kK9kM5ZjprfvyHagKmpw==",
+      "license": "Apache-2.0",
       "bin": {
         "openai": "bin/cli"
       },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "commander": "^14.0.3",
     "dotenv": "^17.3.1",
     "gpt-tokenizer": "^3.4.0",
+    "llm-summary": "github:Cerlancism/llm-summary#3391cc3e51f00c81629d2d7a721ce50f7e537ed2",
     "loglevel": "^1.9.2",
     "openai": "^6.22.0",
     "srt-parser-2": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -11,17 +11,17 @@
   "author": "Cerlancism",
   "license": "MIT",
   "dependencies": {
-    "@streamparser/json-node": "^0.0.22",
-    "@toon-format/toon": "^2.1.0",
-    "commander": "^14.0.3",
-    "dotenv": "^17.3.1",
-    "gpt-tokenizer": "^3.4.0",
-    "llm-summary": "github:Cerlancism/llm-summary#85ffd95f01a52a26750f7a69232cca31faa2abe0",
-    "loglevel": "^1.9.2",
-    "openai": "^6.22.0",
-    "srt-parser-2": "^1.2.3",
-    "undici": "^7.22.0",
-    "zod": "^4.3.6"
+    "@streamparser/json-node": "0.0.22",
+    "@toon-format/toon": "2.1.0",
+    "commander": "14.0.3",
+    "dotenv": "17.4.1",
+    "gpt-tokenizer": "3.4.0",
+    "llm-summary": "github:Cerlancism/llm-summary#fe65dee4a8c70032a611bec6ca31906ae5abbcc2",
+    "loglevel": "1.9.2",
+    "openai": "6.33.0",
+    "srt-parser-2": "1.2.3",
+    "undici": "8.0.2",
+    "zod": "4.3.6"
   },
   "engines": {
     "node": ">=20.0.0"
@@ -31,6 +31,6 @@
   },
   "devDependencies": {
     "@types/node": "^20",
-    "typescript": "^5.9.3"
+    "typescript": "5.9.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "commander": "14.0.3",
     "dotenv": "17.4.1",
     "gpt-tokenizer": "3.4.0",
-    "llm-summary": "github:Cerlancism/llm-summary#fe65dee4a8c70032a611bec6ca31906ae5abbcc2",
+    "llm-summary": "github:Cerlancism/llm-summary#b58ba2cb967aedfa33973c0bd16d0610f614a568",
     "loglevel": "1.9.2",
     "openai": "6.33.0",
     "srt-parser-2": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "commander": "^14.0.3",
     "dotenv": "^17.3.1",
     "gpt-tokenizer": "^3.4.0",
-    "llm-summary": "github:Cerlancism/llm-summary#3391cc3e51f00c81629d2d7a721ce50f7e537ed2",
+    "llm-summary": "github:Cerlancism/llm-summary#85ffd95f01a52a26750f7a69232cca31faa2abe0",
     "loglevel": "^1.9.2",
     "openai": "^6.22.0",
     "srt-parser-2": "^1.2.3",

--- a/src/openai.mjs
+++ b/src/openai.mjs
@@ -30,6 +30,14 @@ export class ChatStreamSyntaxError extends SyntaxError {
     }
 }
 
+export class ChatStreamRepetitionError extends ChatStreamSyntaxError {
+    /** @param {string} pattern */
+    constructor(pattern) {
+        super(`Repetition detected in stream: "${pattern}"`, { cause: "repetition" })
+        this.pattern = pattern
+    }
+}
+
 /**
  * Retry the Openai API function until it succeeds or the maximum number of retries is reached
  * @template T
@@ -108,23 +116,37 @@ export async function streamParse(services, params, zFormat, { jsonStream = fals
  * @param {import("openai/streaming").Stream<import("openai").OpenAI.Chat.Completions.ChatCompletionChunk>} response
  * @param {(d: string) => void} onData
  * @param {(u: import('openai').OpenAI.Completions.CompletionUsage) => void} onEnd
+ * @param {(buffer: string) => boolean} [shouldAbort] - return true to abort the stream (e.g. on repetition detection)
  * @returns {Promise<string>}
  */
-export async function completeChatStream(response, onData = (d) => { }, onEnd = (u) => { }) {
+export async function completeChatStream(response, onData = (d) => { }, onEnd = (u) => { }, shouldAbort = undefined) {
     let output = ''
     return await new Promise(async (resolve, reject) => {
         try {
             /** @type {import('openai').OpenAI.Completions.CompletionUsage} */
             let usage;
+            let repetitionPattern = null
             for await (const part of response) {
                 const text = part.choices[0]?.delta?.content
                 if (text) {
                     output += text
                     onData(text)
+                    if (shouldAbort) {
+                        const detected = shouldAbort(output)
+                        if (detected) {
+                            repetitionPattern = typeof detected === 'string' ? detected : text
+                            try { response.controller.abort() } catch (_) { }
+                            break
+                        }
+                    }
                 }
                 else if (part.usage) {
                     usage = part.usage
                 }
+            }
+            if (repetitionPattern !== null) {
+                reject(new ChatStreamRepetitionError(repetitionPattern))
+                return
             }
             onEnd(usage)
             resolve(output)

--- a/src/openai.mjs
+++ b/src/openai.mjs
@@ -80,12 +80,13 @@ export async function openaiRetryWrapper(func, maxRetries, description) {
  * @param {import('./translator.mjs').TranslationServiceContext} services
  * @param {import('openai').OpenAI.ChatCompletionCreateParams} params
  * @param {{structure: import('zod').ZodType, name: string}} zFormat
- * @param {{jsonStream?: boolean, onJsonStream?: (runner: any) => void, onController?: (controller: AbortController) => void}} [opts]
+ * @param {{jsonStream?: boolean, onJsonStream?: (runner: any) => void, onController?: (controller: AbortController) => void, shouldAbort?: (buffer: string) => string | null}} [opts]
  * @returns {Promise<import('openai/resources/chat/completions/completions.js').ParsedChatCompletion<any>>}
  */
-export async function streamParse(services, params, zFormat, { jsonStream = false, onJsonStream, onController } = {}) {
+export async function streamParse(services, params, zFormat, { jsonStream = false, onJsonStream, onController, shouldAbort } = {}) {
     const zodResponseFormatOutput = zodResponseFormat(zFormat.structure, zFormat.name)
     if (params.stream) {
+        let repetitionPattern = null
         const runner = services.openai.chat.completions.stream({
             ...params,
             response_format: zodResponseFormatOutput,
@@ -96,11 +97,27 @@ export async function streamParse(services, params, zFormat, { jsonStream = fals
         if (jsonStream && onJsonStream) {
             onJsonStream(runner)
         } else {
+            let contentBuffer = ''
             runner.on("content.delta", (e) => {
                 services.onStreamChunk?.(e.delta)
+                if (shouldAbort) {
+                    contentBuffer += e.delta
+                    const pattern = shouldAbort(contentBuffer)
+                    if (pattern) {
+                        repetitionPattern = pattern
+                        runner.controller.abort()
+                    }
+                }
             })
         }
-        await runner.done()
+        try {
+            await runner.done()
+        } catch (error) {
+            if (repetitionPattern) {
+                throw new ChatStreamRepetitionError(repetitionPattern)
+            }
+            throw error
+        }
         services.onStreamEnd?.()
         return runner.finalChatCompletion()
     } else {
@@ -116,7 +133,7 @@ export async function streamParse(services, params, zFormat, { jsonStream = fals
  * @param {import("openai/streaming").Stream<import("openai").OpenAI.Chat.Completions.ChatCompletionChunk>} response
  * @param {(d: string) => void} onData
  * @param {(u: import('openai').OpenAI.Completions.CompletionUsage) => void} onEnd
- * @param {(buffer: string) => boolean} [shouldAbort] - return true to abort the stream (e.g. on repetition detection)
+ * @param {(buffer: string) => string | boolean | null} [shouldAbort] - return a truthy value to abort the stream; if a string is returned it is used as the repetition pattern
  * @returns {Promise<string>}
  */
 export async function completeChatStream(response, onData = (d) => { }, onEnd = (u) => { }, shouldAbort = undefined) {

--- a/src/openai.mjs
+++ b/src/openai.mjs
@@ -61,6 +61,10 @@ export async function openaiRetryWrapper(func, maxRetries, description) {
             log.error(`[Error_${description}]`, "Retries", retryContext.currentTry, "Delay", delay)
             await sleep(delay)
         }
+        else if (error instanceof ChatStreamRepetitionError) {
+            log.warn(`[Error_${description}] ${error.message} - retrying (use --guard-repetition 0 to disable)`, "Retries", retryContext.currentTry, "Delay", delay)
+            await sleep(delay)
+        }
         else if (error instanceof ChatStreamSyntaxError) {
             log.error(`[Error_${description}] ${error.message}`, "Retries", retryContext.currentTry, "Delay", delay)
             await sleep(delay)

--- a/src/translator.mjs
+++ b/src/translator.mjs
@@ -50,6 +50,19 @@ export class Translator extends TranslatorBase {
     }
 
     /**
+     * Repetition detection callback for streaming abort guards.
+     * Returns the repeated pattern if detected, or `null`.
+     * Disabled when `options.guardRepetition` is `0`.
+     * @param {string} buffer
+     * @returns {string | null}
+     */
+    checkRepetition(buffer) {
+        const threshold = this.options.guardRepetition
+        if (!threshold) return null
+        return detectRepetition(buffer, 2, 500, threshold)
+    }
+
+    /**
      * @param {any[]} inputLines
      * @param {string} rawContent
      */
@@ -135,7 +148,7 @@ export class Translator extends TranslatorBase {
                     usage = u
                     this.services.onStreamEnd?.()
                 }, (buffer) => {
-                    return !!detectRepetition(buffer, 2, 500, 3)
+                    return this.checkRepetition(buffer)
                 })
                 return TranslationOutput.fromUsage(this.getOutput(lines, streamOutput), usage)
             }

--- a/src/translator.mjs
+++ b/src/translator.mjs
@@ -135,11 +135,7 @@ export class Translator extends TranslatorBase {
                     usage = u
                     this.services.onStreamEnd?.()
                 }, (buffer) => {
-                    if (!buffer.endsWith('\n')) return false
-                    const lines = buffer.split('\n').filter(Boolean)
-                    if (lines.length < 3) return false
-                    const last10 = lines.slice(-10).join('\n') + '\n'
-                    return !!detectRepetition(last10, 3, 500, 3)
+                    return !!detectRepetition(buffer, 2, 500, 3)
                 })
                 return TranslationOutput.fromUsage(this.getOutput(lines, streamOutput), usage)
             }

--- a/src/translator.mjs
+++ b/src/translator.mjs
@@ -1,6 +1,7 @@
 import log from "loglevel"
 import { countTokens } from "gpt-tokenizer"
 import { openaiRetryWrapper, completeChatStream } from './openai.mjs';
+import { detectRepetition } from 'llm-summary';
 import { checkModeration } from './moderator.mjs';
 import { splitStringByNumberLabel } from './subtitle.mjs';
 import { TranslatorBase, DefaultOptions } from './translatorBase.mjs';
@@ -133,6 +134,12 @@ export class Translator extends TranslatorBase {
                 }, (u) => {
                     usage = u
                     this.services.onStreamEnd?.()
+                }, (buffer) => {
+                    if (!buffer.endsWith('\n')) return false
+                    const lines = buffer.split('\n').filter(Boolean)
+                    if (lines.length < 3) return false
+                    const last10 = lines.slice(-10).join('\n') + '\n'
+                    return !!detectRepetition(last10, 3, 500, 3)
                 })
                 return TranslationOutput.fromUsage(this.getOutput(lines, streamOutput), usage)
             }

--- a/src/translatorAgent.mjs
+++ b/src/translatorAgent.mjs
@@ -3,6 +3,7 @@ import { z } from "zod"
 import { countTokens } from "gpt-tokenizer"
 import { encode as encodeToon } from "@toon-format/toon"
 
+import { summarise } from "llm-summary"
 import { streamParse } from "./openai.mjs"
 import { timestampToMilliseconds } from "./subtitle.mjs"
 import { DefaultOptions } from "./translatorBase.mjs"
@@ -147,24 +148,45 @@ export class TranslatorAgent {
     }
 
     /**
+     * Core usage accumulation: adds prompt/completion counts, updates elapsed time, and logs.
+     * @param {number} promptTokens
+     * @param {number} completionTokens
+     * @param {string} [label]
+     */
+    _addPlanningUsage(promptTokens, completionTokens, label) {
+        const now = Date.now()
+        if (this._planningLastCallTime !== undefined) this.planningElapsedTimeMs += now - this._planningLastCallTime
+        this._planningLastCallTime = now
+        this.planningPromptTokens += promptTokens
+        this.planningCompletionTokens += completionTokens
+        const { planningPromptRate, planningCompletionRate, planningRate } = this.usage
+        log.debug(
+            `[TranslatorAgent]${label ? ` [${label}]` : ""} planning tokens:`,
+            "\n\tStep:", promptTokens, "+", completionTokens, "=", promptTokens + completionTokens,
+            "\n\tTotal:", this.planningPromptTokens, "+", this.planningCompletionTokens, "=", this.planningPromptTokens + this.planningCompletionTokens,
+            ...(planningRate !== undefined ? ["\n\tRate:", planningPromptRate, "+", planningCompletionRate, "=", planningRate, "TPM"] : []),
+        )
+    }
+
+    /**
+     * Accumulates token usage from a SummariseResult and logs it.
+     * @param {import('llm-summary').SummariseResult} result
+     * @param {string} [label]
+     */
+    _accumulateSummariseUsage(result, label) {
+        return this._addPlanningUsage(result.usage.input, result.usage.output, label)
+    }
+
+    /**
      * Accumulates token usage from a planning-pass streamParse response and logs it.
      * @param {import('openai').OpenAI.Chat.ChatCompletion} completion
      * @param {string} [label] - step name for logging
      */
     _accumulatePlanningUsage(completion, label) {
-        const now = Date.now()
-        if (this._planningLastCallTime !== undefined) this.planningElapsedTimeMs += now - this._planningLastCallTime
-        this._planningLastCallTime = now
-        const prompt = completion?.usage?.prompt_tokens ?? 0
-        const completion_ = completion?.usage?.completion_tokens ?? 0
-        this.planningPromptTokens += prompt
-        this.planningCompletionTokens += completion_
-        const { planningPromptRate, planningCompletionRate, planningRate } = this.usage
-        log.debug(
-            `[TranslatorAgent]${label ? ` [${label}]` : ""} planning tokens:`,
-            "\n\tStep:", prompt, "+", completion_, "=", prompt + completion_,
-            "\n\tTotal:", this.planningPromptTokens, "+", this.planningCompletionTokens, "=", this.planningPromptTokens + this.planningCompletionTokens,
-            ...(planningRate !== undefined ? ["\n\tRate:", planningPromptRate, "+", planningCompletionRate, "=", planningRate, "TPM"] : []),
+        return this._addPlanningUsage(
+            completion?.usage?.prompt_tokens ?? 0,
+            completion?.usage?.completion_tokens ?? 0,
+            label
         )
     }
 
@@ -570,70 +592,106 @@ export class TranslatorAgent {
             return null
         }
 
+        const batchSummary = message.parsed?.batchSummary?.trim()
+        if (batchSummary && budget) {
+            const summaryTokens = countTokens(batchSummary)
+            const targetLower = Math.floor(budget * SUMMARY_RANGE_LOWER_FRACTION)
+            if (summaryTokens < targetLower || summaryTokens > budget) {
+                log.debug("[TranslatorAgent]",
+                    `Scan batch summary out of range (${summaryTokens} tokens, target: ${targetLower}-${budget}) - fitting`)
+                const scanFitInstructions =
+                    `Write in ${this.targetLanguage}.\n` +
+                    `Open with your overall impression of this window's content.\n` +
+                    `Write only what is new or notable - do not repeat or refine prior context.\n` +
+                    `Cover the 5W1H: who (names, roles, relationships), what (events, terms, objects), ` +
+                    `where (locations, settings), when (time context), why/how (tone, register, dialect, intent).\n\n` +
+                    `Summary:\n${batchSummary}`
+                try {
+                    await this.services.cooler?.cool()
+                    const result = await summarise(
+                        this.services.openai,
+                        scanFitInstructions,
+                        targetLower,
+                        budget,
+                        {
+                            model: this.options.createChatCompletionRequest.model,
+                            contextBudget: budget
+                        }
+                    )
+                    this._accumulateSummariseUsage(result, "scan_fit")
+                    log.debug("[TranslatorAgent]",
+                        `Scan fit: ${result.tokens} tokens, ${result.attempts} attempts, withinRange: ${result.withinRange}`)
+                    return { batchSummary: result.summary }
+                } catch (error) {
+                    log.warn("[TranslatorAgent]", "Scan batch fit failed:", error?.message, "- using original")
+                }
+            }
+        }
+
         return message.parsed
     }
 
     /**
-     * Calls the model to consolidate an over-budget accumulator with a new note.
-     * Falls back to simple truncation if the model call fails.
+     * Consolidates an over-budget accumulator with a new note into the target token range.
+     * Uses two-phase summarisation (draft → fit) for reliable token range enforcement.
+     * Falls back to simple truncation if the summarise call fails.
      *
      * @param {string} existing - current accumulated batch summaries
      * @param {string} newNote - newly observed batch summary to merge in; pass `""` for final consolidation
-     * @param {number} budget - token budget; also used as max_tokens for the model call
-     * @param {string} agentInstruction - scan guidance from overview pass
+     * @param {number} budget - token budget for the consolidation output
+     * @param {string} [agentInstruction] - scan guidance included in the summarisation instructions
      * @returns {Promise<string>}
      */
     async _consolidateBatchSummaries(existing, newNote = "", budget, agentInstruction) {
         const isFinal = !newNote
         const targetTokens = Math.floor(budget * CONSOLIDATION_TARGET_FRACTION)
         const targetLower = Math.floor(targetTokens * SUMMARY_RANGE_LOWER_FRACTION)
+        const combined = newNote ? `${existing}\n${newNote}` : existing
         const targetRange = `~${targetLower}-${targetTokens} tokens`
         const agentSection = agentInstruction ? `\nScan guidance:\n${agentInstruction}` : ""
-        const messages = /** @type {import('openai').OpenAI.Chat.ChatCompletionMessageParam[]} */ ([
-            {
-                role: "system",
-                content: agentSection + (isFinal
-                    ? `You are doing a final consolidation of all batch summaries for a subtitle file ` +
-                    `into a single complete set of notes (target: ${targetRange}). ` +
-                    `This will be used as the full context for the subtitles - preserve all details.`
-                    : `You are doing consolidation of all given batch summary windows for a subtitle file ` +
-                    `into a single condensed set of notes (target: ${targetRange}). ` +
-                    `More batches will follow - stay concise but keep all unique facts.`) + "\n\n" +
-                    `# Rules:\n` +
-                    `1. Write in ${this.targetLanguage}.\n` +
-                    `2. Open with your overall impression of the content so far.\n` +
-                    `3. Preserve all unique 5W1H facts (who, what, where, when, why/how - names, locations, terms, tone, dialect).\n` +
-                    `4. Remove duplicate or contradictory information. ${isFinal ? "Be thorough - this is the last pass." : "Keep it concise - more content is coming."}`
-            },
-            {
-                role: "user",
-                content: `Batch summaries:\n${existing}`
-            }
-        ])
+        const consolidationInstructions = agentSection +
+            (isFinal
+                ? `You are doing a final consolidation of all batch summaries for a subtitle file ` +
+                `into a single complete set of notes (target: ${targetRange}). ` +
+                `This will be used as the full context for the subtitles - preserve all details.`
+                : `You are doing consolidation of all given batch summary windows for a subtitle file ` +
+                `into a single condensed set of notes (target: ${targetRange}). ` +
+                `More batches will follow - stay concise but keep all unique facts.`) + "\n\n" +
+            `# Rules:\n` +
+            `1. Write in ${this.targetLanguage}.\n` +
+            `2. Open with your overall impression of the content so far.\n` +
+            `3. Preserve all unique 5W1H facts (who, what, where, when, why/how - names, locations, terms, tone, dialect).\n` +
+            `4. Remove duplicate or contradictory information. ${isFinal ? "Be thorough - this is the last pass." : "Keep it concise - more content is coming."}`
+        const inputWithInstructions = `${consolidationInstructions}\n\nBatch summaries:\n${combined}`
         try {
-            const output = await this._streamParse({
-                messages,
-                ...this.options.createChatCompletionRequest,
-                stream: this.options.createChatCompletionRequest.stream,
-                max_tokens: Math.floor(targetTokens * CONSOLIDATION_MAX_TOKENS_MULTIPLIER)
-            }, { structure: consolidateSchema, name: "agent_consolidate" })
-            this._accumulatePlanningUsage(output, "consolidate")
-            const result = output.choices[0]?.message?.parsed?.consolidatedBatchSummary?.trim()
-            if (result) return result
+            const result = await summarise(
+                this.services.openai,
+                inputWithInstructions,
+                targetLower,
+                targetTokens,
+                {
+                    model: this.options.createChatCompletionRequest.model,
+                    contextBudget: budget
+                }
+            )
+            this._accumulateSummariseUsage(result, isFinal ? "consolidate_final" : "consolidate")
+            log.debug("[TranslatorAgent]",
+                `Consolidation${isFinal ? " (final)" : ""}: ${result.tokens} tokens,`,
+                `${result.attempts} attempts, withinRange: ${result.withinRange}`)
+            if (result.summary) return result.summary
         } catch (error) {
             log.warn("[TranslatorAgent]", "Consolidation failed:", error?.message, "- truncating")
         }
         // Fallback: keep as much as fits within budget
-        const combined = `${existing}\n${newNote}`
         if (countTokens(combined) <= budget) return combined
         // Over budget - trim from front of existing to make room for newNote
         const existingLines = existing.split("\n")
         for (let drop = 1; drop < existingLines.length; drop++) {
-            const trimmed = existingLines.slice(drop).join("\n") + "\n" + newNote
+            const trimmed = existingLines.slice(drop).join("\n") + (newNote ? "\n" + newNote : "")
             if (countTokens(trimmed) <= budget) return trimmed
         }
-        // Nothing from existing fits - keep only newNote
-        return newNote
+        // Nothing from existing fits - keep only newNote (or existing if final)
+        return newNote || existing
     }
 
     /**

--- a/src/translatorAgent.mjs
+++ b/src/translatorAgent.mjs
@@ -604,18 +604,18 @@ export class TranslatorAgent {
                     `Open with your overall impression of this window's content.\n` +
                     `Write only what is new or notable - do not repeat or refine prior context.\n` +
                     `Cover the 5W1H: who (names, roles, relationships), what (events, terms, objects), ` +
-                    `where (locations, settings), when (time context), why/how (tone, register, dialect, intent).\n\n` +
-                    `Summary:\n${batchSummary}`
+                    `where (locations, settings), when (time context), why/how (tone, register, dialect, intent).`
                 try {
                     await this.services.cooler?.cool()
                     const result = await summarise(
                         this.services.openai,
-                        scanFitInstructions,
+                        batchSummary,
                         targetLower,
                         budget,
                         {
                             model: this.options.createChatCompletionRequest.model,
-                            contextBudget: budget
+                            contextBudget: budget,
+                            instructions: scanFitInstructions
                         }
                     )
                     this._accumulateSummariseUsage(result, "scan_fit")
@@ -662,16 +662,16 @@ export class TranslatorAgent {
             `2. Open with your overall impression of the content so far.\n` +
             `3. Preserve all unique 5W1H facts (who, what, where, when, why/how - names, locations, terms, tone, dialect).\n` +
             `4. Remove duplicate or contradictory information. ${isFinal ? "Be thorough - this is the last pass." : "Keep it concise - more content is coming."}`
-        const inputWithInstructions = `${consolidationInstructions}\n\nBatch summaries:\n${combined}`
         try {
             const result = await summarise(
                 this.services.openai,
-                inputWithInstructions,
+                combined,
                 targetLower,
                 targetTokens,
                 {
                     model: this.options.createChatCompletionRequest.model,
-                    contextBudget: budget
+                    contextBudget: budget,
+                    instructions: consolidationInstructions
                 }
             )
             this._accumulateSummariseUsage(result, isFinal ? "consolidate_final" : "consolidate")

--- a/src/translatorAgent.mjs
+++ b/src/translatorAgent.mjs
@@ -178,6 +178,20 @@ export class TranslatorAgent {
     }
 
     /**
+     * Builds a base {@link import('llm-summary').SummariseOptions} object with model and verbose
+     * derived from current options and log level, merged with any call-specific overrides.
+     * @param {import('llm-summary').SummariseOptions} [extras] - call-specific overrides
+     * @returns {import('llm-summary').SummariseOptions}
+     */
+    _summariseOptions(extras = {}) {
+        return {
+            model: this.options.createChatCompletionRequest.model,
+            verbose: log.getLevel() <= log.levels.DEBUG,
+            ...extras
+        }
+    }
+
+    /**
      * Accumulates token usage from a planning-pass streamParse response and logs it.
      * @param {import('openai').OpenAI.Chat.ChatCompletion} completion
      * @param {string} [label] - step name for logging
@@ -612,11 +626,7 @@ export class TranslatorAgent {
                         batchSummary,
                         targetLower,
                         budget,
-                        {
-                            model: this.options.createChatCompletionRequest.model,
-                            contextBudget: budget,
-                            instructions: scanFitInstructions
-                        }
+                        this._summariseOptions({ contextBudget: budget, instructions: scanFitInstructions })
                     )
                     this._accumulateSummariseUsage(result, "scan_fit")
                     log.debug("[TranslatorAgent]",
@@ -668,11 +678,7 @@ export class TranslatorAgent {
                 combined,
                 targetLower,
                 targetTokens,
-                {
-                    model: this.options.createChatCompletionRequest.model,
-                    contextBudget: budget,
-                    instructions: consolidationInstructions
-                }
+                this._summariseOptions({ contextBudget: budget, instructions: consolidationInstructions })
             )
             this._accumulateSummariseUsage(result, isFinal ? "consolidate_final" : "consolidate")
             log.debug("[TranslatorAgent]",

--- a/src/translatorAgent.mjs
+++ b/src/translatorAgent.mjs
@@ -602,7 +602,7 @@ export class TranslatorAgent {
         }
 
         const batchSummary = message.parsed?.batchSummary?.trim()
-        if (batchSummary && budget) {
+        if (batchSummary && budget && !this.options.skipFitting) {
             const summaryTokens = countTokens(batchSummary)
             const targetLower = Math.floor(budget * SUMMARY_RANGE_LOWER_FRACTION)
             if (summaryTokens < targetLower || summaryTokens > budget) {
@@ -667,21 +667,23 @@ export class TranslatorAgent {
             `2. Open with your overall impression of the content so far.\n` +
             `3. Preserve all unique 5W1H facts (who, what, where, when, why/how - names, locations, terms, tone, dialect).\n` +
             `4. Remove duplicate or contradictory information. ${isFinal ? "Be thorough - this is the last pass." : "Keep it concise - more content is coming."}`
-        try {
-            const result = await summarise(
-                this.services.openai,
-                combined,
-                targetLower,
-                targetTokens,
-                this._summariseOptions({ contextBudget: budget, instructions: consolidationInstructions })
-            )
-            this._accumulateSummariseUsage(result, isFinal ? "consolidate_final" : "consolidate")
-            log.debug("[TranslatorAgent]",
-                `Consolidation${isFinal ? " (final)" : ""}: ${result.tokens} tokens,`,
-                `${result.attempts} attempts, withinRange: ${result.withinRange}`)
-            if (result.summary) return result.summary
-        } catch (error) {
-            log.warn("[TranslatorAgent]", "Consolidation failed:", error?.message, "- truncating")
+        if (!this.options.skipFitting) {
+            try {
+                const result = await summarise(
+                    this.services.openai,
+                    combined,
+                    targetLower,
+                    targetTokens,
+                    this._summariseOptions({ contextBudget: budget, instructions: consolidationInstructions })
+                )
+                this._accumulateSummariseUsage(result, isFinal ? "consolidate_final" : "consolidate")
+                log.debug("[TranslatorAgent]",
+                    `Consolidation${isFinal ? " (final)" : ""}: ${result.tokens} tokens,`,
+                    `${result.attempts} attempts, withinRange: ${result.withinRange}`)
+                if (result.summary) return result.summary
+            } catch (error) {
+                log.warn("[TranslatorAgent]", "Consolidation failed:", error?.message, "- truncating")
+            }
         }
         // Fallback: keep as much as fits within budget
         if (countTokens(combined) <= budget) return combined

--- a/src/translatorAgent.mjs
+++ b/src/translatorAgent.mjs
@@ -15,14 +15,9 @@ const scanBatchSchema = z.object({
     batchSummary: z.string().describe("Translation notes for this scan window.")
 })
 
-const consolidateSchema = z.object({
-    consolidatedBatchSummary: z.string().describe("Synthesis of the provided batch summaries.")
-})
-
 const finalInstructionSchema = z.object({
     finalInstruction: z.string().describe("Translation system instruction for this subtitle file.")
 })
-
 
 const overviewSchema = z.object({
     overview: z.string().describe("Content overview of the subtitle file.")

--- a/src/translatorBase.mjs
+++ b/src/translatorBase.mjs
@@ -42,7 +42,9 @@ import { roundWithPrecision, sleep } from './helpers.mjs'
  * Structured response format mode
  * @property {boolean} skipRefineInstruction
  * Skip the final instruction refinement API call in agent mode; use the base system instruction directly
- * @property {string} agentContextSummary  
+ * @property {boolean} skipFitting
+ * Skip LLM-based token-range fitting for planning summaries and consolidation in agent mode
+ * @property {string} agentContextSummary
  * Pre-supplied context summary for agent mode; skips the batch scanning pass entirely
  * @property {number} guardRepetition `10`
  * Minimum number of pattern repeats before aborting a streaming response. Set to `0` to disable repetition detection.

--- a/src/translatorBase.mjs
+++ b/src/translatorBase.mjs
@@ -44,6 +44,8 @@ import { roundWithPrecision, sleep } from './helpers.mjs'
  * Skip the final instruction refinement API call in agent mode; use the base system instruction directly
  * @property {string} agentContextSummary  
  * Pre-supplied context summary for agent mode; skips the batch scanning pass entirely
+ * @property {number} guardRepetition `10`
+ * Minimum number of pattern repeats before aborting a streaming response. Set to `0` to disable repetition detection.
  * @property {number} max_token `0`
  * @property {number} inputMultiplier `0`
  * @property {import('loglevel').LogLevelDesc} logLevel
@@ -64,6 +66,7 @@ export const DefaultOptions = {
     useFullContext: 2000,
     batchSizes: undefined,
     structuredMode: "array",
+    guardRepetition: 10,
     max_token: 0,
     inputMultiplier: 0,
     logLevel: undefined

--- a/src/translatorStructuredArray.mjs
+++ b/src/translatorStructuredArray.mjs
@@ -68,7 +68,9 @@ export class TranslatorStructuredArray extends TranslatorStructuredBase {
 
             return TranslationOutput.fromCompletion(linesOut, output)
         } catch (error) {
-            log.error("[TranslatorStructuredArray]", `Error ${error?.constructor?.name}`, error?.message)
+            if (!this._repetitionDetected) {
+                log.error("[TranslatorStructuredArray]", `Error ${error?.constructor?.name}`, error?.message)
+            }
             return this.handleTranslateError(error, lines.length)
         }
     }
@@ -94,12 +96,18 @@ export class TranslatorStructuredArray extends TranslatorStructuredBase {
         this.services.onStreamChunk?.("\n")
         const passThroughStream = new PassThrough()
         let writeBuffer = ''
+        let contentBuffer = ''
         runner.on("content.delta", (e) => {
             writeBuffer += e.delta
+            contentBuffer += e.delta
             passThroughStream.write(e.delta)
             if (writeBuffer) {
                 this.services.onStreamChunk?.(writeBuffer)
                 writeBuffer = ''
+            }
+            const pattern = this.checkRepetition(contentBuffer)
+            if (pattern) {
+                this.abortOnRepetition(pattern, runner)
             }
         })
         runner.on("content.done", () => {

--- a/src/translatorStructuredBase.mjs
+++ b/src/translatorStructuredBase.mjs
@@ -30,7 +30,7 @@ export class TranslatorStructuredBase extends Translator {
      * @param {import('openai/lib/ChatCompletionStream').ChatCompletionStream<any>} runner
      */
     abortOnRepetition(pattern, runner) {
-        log.warn(`[${this.constructor.name}]`, `Repetition detected: "${pattern.slice(0, 50)}"`)
+        log.warn(`[${this.constructor.name}]`, `Repetition detected: "${pattern.slice(0, 50)}" — retrying (use --guard-repetition 0 to disable)`)
         this._repetitionDetected = true
         runner.controller.abort()
     }
@@ -43,7 +43,7 @@ export class TranslatorStructuredBase extends Translator {
     handleTranslateError(error, lineCount) {
         if (error instanceof ChatStreamRepetitionError || this._repetitionDetected) {
             const pattern = error instanceof ChatStreamRepetitionError ? error.pattern : ''
-            log.warn(`[${this.constructor.name}]`, `Retrying after repetition abort${pattern ? `: "${pattern.slice(0, 50)}"` : ''}`)
+            log.warn(`[${this.constructor.name}]`, `Retrying after repetition abort${pattern ? `: "${pattern.slice(0, 50)}"` : ''} (use --guard-repetition 0 to disable)`)
             this._repetitionDetected = false
             return new TranslationOutput([], 0, 0, 0, 0)
         }

--- a/src/translatorStructuredBase.mjs
+++ b/src/translatorStructuredBase.mjs
@@ -2,6 +2,7 @@ import { APIUserAbortError } from "openai/error.mjs";
 import log from "loglevel"
 import { Translator } from "./translator.mjs";
 import { TranslationOutput } from "./translatorOutput.mjs";
+import { ChatStreamRepetitionError } from "./openai.mjs";
 
 /**
  * @abstract
@@ -19,6 +20,19 @@ export class TranslatorStructuredBase extends Translator {
         log.debug(`[TranslatorStructuredBase]`, "Structured Mode:", options.structuredMode)
         options.prefixNumber = false
         super(language, services, options)
+        /** @protected */
+        this._repetitionDetected = false
+    }
+
+    /**
+     * Mark repetition detected and abort the runner (for jsonStream subclasses).
+     * @param {string} pattern
+     * @param {import('openai/lib/ChatCompletionStream').ChatCompletionStream<any>} runner
+     */
+    abortOnRepetition(pattern, runner) {
+        log.warn(`[${this.constructor.name}]`, `Repetition detected: "${pattern.slice(0, 50)}"`)
+        this._repetitionDetected = true
+        runner.controller.abort()
     }
 
     /**
@@ -27,6 +41,12 @@ export class TranslatorStructuredBase extends Translator {
      * @returns {TranslationOutput | undefined}
      */
     handleTranslateError(error, lineCount) {
+        if (error instanceof ChatStreamRepetitionError || this._repetitionDetected) {
+            const pattern = error instanceof ChatStreamRepetitionError ? error.pattern : ''
+            log.warn(`[${this.constructor.name}]`, `Retrying after repetition abort${pattern ? `: "${pattern.slice(0, 50)}"` : ''}`)
+            this._repetitionDetected = false
+            return new TranslationOutput([], 0, 0, 0, 0)
+        }
         if (error instanceof APIUserAbortError) {
             return undefined
         }

--- a/src/translatorStructuredObject.mjs
+++ b/src/translatorStructuredObject.mjs
@@ -3,7 +3,7 @@ import log from "loglevel"
 
 import { TranslationOutput } from "./translatorOutput.mjs";
 import { TranslatorStructuredBase } from "./translatorStructuredBase.mjs";
-import { streamParse } from "./openai.mjs";
+import { streamParse, ChatStreamRepetitionError } from "./openai.mjs";
 
 const NestedPlaceholder = "nested_"
 
@@ -61,7 +61,10 @@ export class TranslatorStructuredObject extends TranslatorStructuredBase {
             }, {
                 structure: translationBatch,
                 name: "translation_object"
-            }, { onController: (c) => { this.streamController = c } })
+            }, {
+                onController: (c) => { this.streamController = c },
+                shouldAbort: (buffer) => this.checkRepetition(buffer),
+            })
 
             // log.debug("[TranslatorStructuredObject]", output.choices[0].message.content)
 
@@ -102,7 +105,9 @@ export class TranslatorStructuredObject extends TranslatorStructuredBase {
 
             return TranslationOutput.fromCompletion(linesOut, output)
         } catch (error) {
-            log.error("[TranslatorStructuredObject]", `Error ${error?.constructor?.name}`, error?.message)
+            if (!(error instanceof ChatStreamRepetitionError)) {
+                log.error("[TranslatorStructuredObject]", `Error ${error?.constructor?.name}`, error?.message)
+            }
             return this.handleTranslateError(error, lines.length)
         }
     }

--- a/src/translatorStructuredTimestamp.mjs
+++ b/src/translatorStructuredTimestamp.mjs
@@ -3,7 +3,6 @@ import { z } from "zod";
 import { JSONParser } from "@streamparser/json-node";
 import log from "loglevel"
 import { countTokens } from "gpt-tokenizer"
-import { detectRepetition } from "llm-summary";
 
 import { TranslationOutput } from "./translatorOutput.mjs";
 import { TranslatorStructuredBase } from "./translatorStructuredBase.mjs";
@@ -365,20 +364,6 @@ export class TranslatorStructuredTimestamp extends TranslatorStructuredBase {
         }
     }
 
-    /**
-     * @override
-     * @param {Error} error
-     * @param {number} lineCount
-     * @returns {TranslationOutput | undefined}
-     */
-    handleTranslateError(error, lineCount) {
-        if (this._repetitionDetected) {
-            this._repetitionDetected = false
-            log.warn("[TranslatorStructuredTimestamp]", "Retrying after repetition abort")
-            return new TranslationOutput([], 0, 0, 0, 0)
-        }
-        return super.handleTranslateError(error, lineCount)
-    }
 
     /**
      * @param {import('openai/lib/ChatCompletionStream').ChatCompletionStream<any>} runner
@@ -458,11 +443,9 @@ export class TranslatorStructuredTimestamp extends TranslatorStructuredBase {
                         textBuffer += '\n'
                         textBufEntryLen = 0
                     }
-                    const pattern = detectRepetition(textBuffer, 2, 500, 3)
+                    const pattern = this.checkRepetition(textBuffer)
                     if (pattern) {
-                        log.warn("[TranslatorStructuredTimestamp]", `Repetition detected: "${pattern.slice(0, 50)}"`)
-                        this._repetitionDetected = true
-                        runner.controller.abort()
+                        this.abortOnRepetition(pattern, runner)
                     }
                 } else if (key === "remarksIfContainedMergers") {
                     const strValue = /** @type {string} */(value)

--- a/src/translatorStructuredTimestamp.mjs
+++ b/src/translatorStructuredTimestamp.mjs
@@ -457,16 +457,12 @@ export class TranslatorStructuredTimestamp extends TranslatorStructuredBase {
                     if (!partial) {
                         textBuffer += '\n'
                         textBufEntryLen = 0
-                        const entries = textBuffer.split('\n').filter(Boolean)
-                        if (entries.length >= 3) {
-                            const last10 = entries.slice(-10).join('\n') + '\n'
-                            const pattern = detectRepetition(last10, 3, 500, 3)
-                            if (pattern) {
-                                log.warn("[TranslatorStructuredTimestamp]", `Repetition detected: "${pattern.slice(0, 50)}"`)
-                                this._repetitionDetected = true
-                                runner.controller.abort()
-                            }
-                        }
+                    }
+                    const pattern = detectRepetition(textBuffer, 2, 500, 3)
+                    if (pattern) {
+                        log.warn("[TranslatorStructuredTimestamp]", `Repetition detected: "${pattern.slice(0, 50)}"`)
+                        this._repetitionDetected = true
+                        runner.controller.abort()
                     }
                 } else if (key === "remarksIfContainedMergers") {
                     const strValue = /** @type {string} */(value)

--- a/src/translatorStructuredTimestamp.mjs
+++ b/src/translatorStructuredTimestamp.mjs
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { JSONParser } from "@streamparser/json-node";
 import log from "loglevel"
 import { countTokens } from "gpt-tokenizer"
+import { detectRepetition } from "llm-summary";
 
 import { TranslationOutput } from "./translatorOutput.mjs";
 import { TranslatorStructuredBase } from "./translatorStructuredBase.mjs";
@@ -119,7 +120,9 @@ export class TranslatorStructuredTimestamp extends TranslatorStructuredBase {
 
             return TranslationOutput.fromCompletion(/** @type {any} */(parsed), output)
         } catch (error) {
-            log.error("[TranslatorStructuredTimestamp]", `Error ${error?.constructor?.name}`, error?.message)
+            if (!this._repetitionDetected) {
+                log.error("[TranslatorStructuredTimestamp]", `Error ${error?.constructor?.name}`, error?.message)
+            }
             return this.handleTranslateError(error, entries.length)
         }
     }
@@ -363,6 +366,21 @@ export class TranslatorStructuredTimestamp extends TranslatorStructuredBase {
     }
 
     /**
+     * @override
+     * @param {Error} error
+     * @param {number} lineCount
+     * @returns {TranslationOutput | undefined}
+     */
+    handleTranslateError(error, lineCount) {
+        if (this._repetitionDetected) {
+            this._repetitionDetected = false
+            log.warn("[TranslatorStructuredTimestamp]", "Retrying after repetition abort")
+            return new TranslationOutput([], 0, 0, 0, 0)
+        }
+        return super.handleTranslateError(error, lineCount)
+    }
+
+    /**
      * @param {import('openai/lib/ChatCompletionStream').ChatCompletionStream<any>} runner
      */
     jsonStreamParse(runner) {
@@ -380,6 +398,10 @@ export class TranslatorStructuredTimestamp extends TranslatorStructuredBase {
         let textDone = true
         let expectedIdx = -1
         const currentBatchEntries = /** @type {TimestampEntry[]} */ (this.currentBatchEntries ?? [])
+
+        /** Text-only buffer for repetition detection (timestamps excluded) */
+        let textBuffer = ''
+        let textBufEntryLen = 0
 
         /**
          * @param {"start"|"end"|"text"} fieldKey
@@ -413,6 +435,7 @@ export class TranslatorStructuredTimestamp extends TranslatorStructuredBase {
                 if (key === "start") {
                     if (textDone) {
                         prevLen.start = prevLen.end = prevLen.text = 0
+                        textBufEntryLen = 0
                         textDone = false
                         expectedIdx++
                     }
@@ -427,6 +450,24 @@ export class TranslatorStructuredTimestamp extends TranslatorStructuredBase {
                     if (!partial) emitField("end", "  ", millisecondsToTimestamp(/** @type {number} */(value)), partial)
                 } else if (key === "text") {
                     emitField("text", "\n", /** @type {string} */(value), partial, () => { textDone = true })
+                    const strValue = /** @type {string} */(value)
+                    const delta = strValue.slice(textBufEntryLen)
+                    textBuffer += delta
+                    textBufEntryLen = strValue.length
+                    if (!partial) {
+                        textBuffer += '\n'
+                        textBufEntryLen = 0
+                        const entries = textBuffer.split('\n').filter(Boolean)
+                        if (entries.length >= 3) {
+                            const last10 = entries.slice(-10).join('\n') + '\n'
+                            const pattern = detectRepetition(last10, 3, 500, 3)
+                            if (pattern) {
+                                log.warn("[TranslatorStructuredTimestamp]", `Repetition detected: "${pattern.slice(0, 50)}"`)
+                                this._repetitionDetected = true
+                                runner.controller.abort()
+                            }
+                        }
+                    }
                 } else if (key === "remarksIfContainedMergers") {
                     const strValue = /** @type {string} */(value)
                     if (strValue) {

--- a/src/translatorStructuredTimestamp.mjs
+++ b/src/translatorStructuredTimestamp.mjs
@@ -450,7 +450,7 @@ export class TranslatorStructuredTimestamp extends TranslatorStructuredBase {
                     if (!partial) emitField("end", "  ", millisecondsToTimestamp(/** @type {number} */(value)), partial)
                 } else if (key === "text") {
                     emitField("text", "\n", /** @type {string} */(value), partial, () => { textDone = true })
-                    const strValue = /** @type {string} */(value)
+                    const strValue = /** @type {string} */(value ?? '')
                     const delta = strValue.slice(textBufEntryLen)
                     textBuffer += delta
                     textBufEntryLen = strValue.length

--- a/test/translator.test.mjs
+++ b/test/translator.test.mjs
@@ -27,8 +27,9 @@ test('should output subtitles', async () => {
         }
     }, {
         createChatCompletionRequest: {
+            model: process.env.OPENAI_DEFAULT_MODEL,
             temperature: 0,
-            stream: true
+            stream: true,
         },
         batchSizes: [2, 3],
     });


### PR DESCRIPTION
#### Repetition Guard (`-g, --guard-repetition`)

Detects when a model falls into a repetition loop during streaming and aborts the request early, then retries with a smaller batch. Enabled by default with a threshold of `10` pattern repeats.

#### LLM-Powered Summary Fitting (Agent Mode)

The agent planning pass now uses the [`llm-summary`](https://github.com/Cerlancism/llm-summary) library for token-range-aware summarisation.