### PR TITLE
fix: harden structured streaming retries

### DIFF
--- a/src/translator.mjs
+++ b/src/translator.mjs
@@ -294,6 +294,9 @@ export class Translator extends TranslatorBase {
             return lines.length - startIndex
         }
         const budget = Math.floor(useFullContext * DYNAMIC_BATCH_BUDGET_FRACTION / reductionFactor)
+        if (budget <= 0) {
+            return Math.min(AUTO_BATCH_MIN, lines.length - startIndex)
+        }
         const weights = lines.map(l => this.getLineTokenWeight(l))
         return computeEvenBatchSize(weights, startIndex, budget)
     }

--- a/src/translatorStructuredArray.mjs
+++ b/src/translatorStructuredArray.mjs
@@ -67,9 +67,16 @@ export class TranslatorStructuredArray extends TranslatorStructuredBase {
     jsonStreamParse(runner) {
         this.services.onStreamChunk?.("\n")
         const passThroughStream = new PassThrough()
+        let passThroughEnded = false
         let writeBuffer = ''
         let contentBuffer = ''
+        passThroughStream.on("error", (/** @type {Error} */ err) => {
+            log.debug("[TranslatorStructuredArray]", "stream buffer error:", err.message)
+        })
         runner.on("content.delta", (e) => {
+            if (passThroughEnded || passThroughStream.destroyed || passThroughStream.writableEnded) {
+                return
+            }
             writeBuffer += e.delta
             contentBuffer += e.delta
             passThroughStream.write(e.delta)
@@ -83,6 +90,8 @@ export class TranslatorStructuredArray extends TranslatorStructuredBase {
             }
         })
         runner.on("content.done", () => {
+            if (passThroughEnded) return
+            passThroughEnded = true
             passThroughStream.end()
             this.services.onClearLine?.()
         })

--- a/src/translatorStructuredTimestamp.mjs
+++ b/src/translatorStructuredTimestamp.mjs
@@ -281,13 +281,23 @@ export class TranslatorStructuredTimestamp extends TranslatorStructuredBase {
      */
     jsonStreamParse(runner) {
         const passThroughStream = new PassThrough()
+        let passThroughEnded = false
+        passThroughStream.on("error", (/** @type {Error} */ err) => {
+            log.debug("[TranslatorStructuredTimestamp]", "stream buffer error:", err.message)
+        })
 
         runner.on("content.delta", (e) => {
+            if (passThroughEnded || passThroughStream.destroyed || passThroughStream.writableEnded) {
+                return
+            }
             passThroughStream.write(e.delta)
         })
 
         runner.on("content.done", () => {
-            passThroughStream.end()
+            if (!passThroughEnded) {
+                passThroughEnded = true
+                passThroughStream.end()
+            }
         })
 
         const currentBatchEntries = /** @type {TimestampEntry[]} */ (this.currentBatchEntries ?? [])

--- a/test/translatorBatch.test.mjs
+++ b/test/translatorBatch.test.mjs
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { Translator, AUTO_BATCH_MIN } from '../src/translator.mjs';
+
+test('dynamic batch reduction falls back to minimum batch size when budget rounds to zero', () => {
+    const translator = new Translator({ from: 'English', to: 'Finnish' }, { openai: null }, {
+        useFullContext: 2000,
+    });
+    const lines = Array.from({ length: 1476 }, (_, index) => `Subtitle line ${index}`);
+
+    const batchSize = translator.computeDynamicBatchSize(lines, 272, Number.MAX_SAFE_INTEGER);
+
+    assert.equal(batchSize, AUTO_BATCH_MIN);
+});
+
+test('dynamic batch reduction does not exceed remaining line count', () => {
+    const translator = new Translator({ from: 'English', to: 'Finnish' }, { openai: null }, {
+        useFullContext: 2000,
+    });
+    const lines = ['one', 'two'];
+
+    const batchSize = translator.computeDynamicBatchSize(lines, 0, Number.MAX_SAFE_INTEGER);
+
+    assert.equal(batchSize, 2);
+});

--- a/test/translatorStructuredStream.test.mjs
+++ b/test/translatorStructuredStream.test.mjs
@@ -1,0 +1,84 @@
+import { EventEmitter } from 'node:events';
+import { setImmediate } from 'node:timers/promises';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { TranslatorStructuredArray } from '../src/translatorStructuredArray.mjs';
+import { TranslatorStructuredTimestamp } from '../src/translatorStructuredTimestamp.mjs';
+
+function makeRunner() {
+    const runner = /** @type {any} */ (new EventEmitter());
+    runner.controller = { abort() { } };
+    return runner;
+}
+
+/**
+ * @param {() => void | Promise<void>} fn
+ */
+async function captureProcessErrors(fn) {
+    const errors = [];
+    const onError = (/** @type {unknown} */ error) => {
+        errors.push(error);
+    };
+    process.prependListener('uncaughtException', onError);
+    process.prependListener('unhandledRejection', onError);
+    try {
+        await fn();
+        await setImmediate();
+    } finally {
+        process.removeListener('uncaughtException', onError);
+        process.removeListener('unhandledRejection', onError);
+    }
+    return errors;
+}
+
+test('structured array stream parser ignores late content delta after done', async () => {
+    const chunks = [];
+    let clearCount = 0;
+    const translator = new TranslatorStructuredArray({ from: 'English', to: 'Finnish' }, {
+        openai: null,
+        onStreamChunk: (data) => chunks.push(data),
+        onClearLine: () => { clearCount++ },
+    }, {
+        createChatCompletionRequest: { model: 'fake', stream: true },
+        logLevel: 'silent',
+    });
+    const runner = makeRunner();
+
+    const errors = await captureProcessErrors(() => {
+        translator.jsonStreamParse(runner);
+        runner.emit('content.delta', { delta: '{"outputs":["Hei"]}' });
+        runner.emit('content.done');
+        runner.emit('content.delta', { delta: ' late data' });
+        runner.emit('content.done');
+    });
+
+    assert.deepEqual(errors, []);
+    assert.ok(chunks.some(chunk => chunk.includes('Hei')));
+    assert.ok(!chunks.some(chunk => chunk.includes('late data')));
+    assert.equal(clearCount, 2);
+});
+
+test('structured timestamp stream parser ignores late content delta after done', async () => {
+    const chunks = [];
+    const translator = new TranslatorStructuredTimestamp({ from: 'English', to: 'Finnish' }, {
+        openai: null,
+        onStreamChunk: (data) => chunks.push(data),
+    }, {
+        createChatCompletionRequest: { model: 'fake', stream: true },
+        logLevel: 'silent',
+    });
+    const runner = makeRunner();
+
+    const errors = await captureProcessErrors(() => {
+        translator.jsonStreamParse(runner);
+        runner.emit('content.delta', { delta: '{"outputs":[{"start":0,"end":1000,"text":"Hei"}]}' });
+        runner.emit('content.done');
+        runner.emit('content.delta', { delta: ' late data' });
+        runner.emit('content.done');
+    });
+
+    assert.deepEqual(errors, []);
+    assert.ok(chunks.some(chunk => chunk.includes('Hei')));
+    assert.ok(!chunks.some(chunk => chunk.includes('late data')));
+});


### PR DESCRIPTION
The translation first crashed, and then, after fixing that, was stuck in an endless loop, when trying to use the agentic mode to translate from English to Finnish using Gemma 4 via  OpenRouter.

This PR has a fix to prevent structured streaming preview parsers from writing after content.done, ignore late deltas, and keep dynamic retry batching from expanding back to the full remaining file when retry budget rounds to zero. Testing: node --test test/translatorStructuredStream.test.mjs; node --test test/translatorBatch.test.mjs; npm run typecheck.